### PR TITLE
src: fix build on MSVC

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -57,7 +57,7 @@ do {                                                                 \
 } while(0)
 
 #define CURRENT_STATE() p_state
-#define UPDATE_STATE(V) p_state = (V);
+#define UPDATE_STATE(V) p_state = (enum state) (V);
 #define RETURN(V)                                                    \
 do {                                                                 \
   parser->state = CURRENT_STATE();                                   \
@@ -637,7 +637,7 @@ size_t http_parser_execute (http_parser *parser,
   const char *url_mark = 0;
   const char *body_mark = 0;
   const char *status_mark = 0;
-  enum state p_state = parser->state;
+  enum state p_state = (enum state) parser->state;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -1518,7 +1518,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_header_value:
       {
         const char* start = p;
-        enum header_states h_state = parser->header_state;
+        enum header_states h_state = (enum header_states) parser->header_state;
         for (; p != data + len; p++) {
           ch = *p;
           if (ch == CR) {
@@ -1547,8 +1547,8 @@ size_t http_parser_execute (http_parser *parser,
 
               limit = MIN(limit, HTTP_MAX_HEADER_SIZE);
 
-              p_cr = memchr(p, CR, limit);
-              p_lf = memchr(p, LF, limit);
+              p_cr = (const char*) memchr(p, CR, limit);
+              p_lf = (const char*) memchr(p, LF, limit);
               if (p_cr != NULL) {
                 if (p_lf != NULL && p_cr >= p_lf)
                   p = p_lf;


### PR DESCRIPTION
Do explicit casts from/to enums, convert type of `memchr`'s return value
to `const char*`.

cc @piscisaureus