### PR TITLE
Add function to initialize http_parser_settings

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2134,6 +2134,19 @@ http_parser_init (http_parser *parser, enum http_parser_type t)
   parser->http_errno = HPE_OK;
 }
 
+void
+http_parser_settings_init(http_parser_settings *settings)
+{
+  settings->on_message_begin = 0;
+  settings->on_url = 0;
+  settings->on_status = 0;
+  settings->on_header_field = 0;
+  settings->on_header_value = 0;
+  settings->on_headers_complete = 0;
+  settings->on_body = 0;
+  settings->on_message_complete = 0;
+}
+
 const char *
 http_errno_name(enum http_errno err) {
   assert(err < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));

--- a/http_parser.c
+++ b/http_parser.c
@@ -2137,14 +2137,7 @@ http_parser_init (http_parser *parser, enum http_parser_type t)
 void
 http_parser_settings_init(http_parser_settings *settings)
 {
-  settings->on_message_begin = 0;
-  settings->on_url = 0;
-  settings->on_status = 0;
-  settings->on_header_field = 0;
-  settings->on_header_value = 0;
-  settings->on_headers_complete = 0;
-  settings->on_body = 0;
-  settings->on_message_complete = 0;
+  memset(settings, 0, sizeof(*settings));
 }
 
 const char *

--- a/http_parser.h
+++ b/http_parser.h
@@ -288,6 +288,11 @@ unsigned long http_parser_version(void);
 void http_parser_init(http_parser *parser, enum http_parser_type type);
 
 
+/* Initialize http_parser_settings members to 0
+ */
+void http_parser_settings_init(http_parser_settings *settings);
+
+
 /* Executes the parser. Returns number of parsed bytes. Sets
  * `parser->http_errno` on error. */
 size_t http_parser_execute(http_parser *parser,


### PR DESCRIPTION
When http_parser_settings struct is defined in function or class scope, struct members are not initilized to 0.