### PR TITLE
src: partially revert 959f4cb to fix nread value

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -64,8 +64,7 @@ do {                                                                 \
   return (V);                                                        \
 } while (0);
 #define REEXECUTE()                                                  \
-  --p;                                                               \
-  break;
+  goto reexecute;                                                    \
 
 
 #ifdef __GNUC__
@@ -697,6 +696,7 @@ size_t http_parser_execute (http_parser *parser,
     if (PARSING_HEADER(CURRENT_STATE()))
       COUNT_HEADER_SIZE(1);
 
+reexecute:
     switch (CURRENT_STATE()) {
 
       case s_dead:

--- a/test.c
+++ b/test.c
@@ -3044,6 +3044,22 @@ test_header_overflow_error (int req)
   abort();
 }
 
+
+void
+test_header_nread_value ()
+{
+  http_parser parser;
+  http_parser_init(&parser, HTTP_REQUEST);
+  size_t parsed;
+  const char *buf;
+  buf = "GET / HTTP/1.1\r\nheader: value\nhdr: value\r\n";
+  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
+  assert(parsed == strlen(buf));
+
+  assert(parser.nread == strlen(buf));
+}
+
+
 static void
 test_content_length_overflow (const char *buf, size_t buflen, int expect_ok)
 {
@@ -3409,6 +3425,9 @@ main (void)
   test_preserve_data();
   test_parse_url();
   test_method_str();
+
+  //// NREAD
+  test_header_nread_value();
 
   //// OVERFLOW CONDITIONS
 


### PR DESCRIPTION
With 959f4cb on reexecution - header byte was accounted twice, leading
to the incorrect `parser->nread` value.

Fix: #220