### PR TITLE
Closes #231 : add callbacks for processing chunk boundaries

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2147,13 +2147,15 @@ http_parser_settings_init(http_parser_settings *settings)
 
 const char *
 http_errno_name(enum http_errno err) {
-  assert(((size_t)err) < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
+  assert(((size_t)err)
+      < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].name;
 }
 
 const char *
 http_errno_description(enum http_errno err) {
-  assert(((size_t)err) < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
+  assert(((size_t)err)
+      < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].description;
 }
 

--- a/http_parser.c
+++ b/http_parser.c
@@ -123,7 +123,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-
+  
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)

--- a/http_parser.c
+++ b/http_parser.c
@@ -2147,13 +2147,13 @@ http_parser_settings_init(http_parser_settings *settings)
 
 const char *
 http_errno_name(enum http_errno err) {
-  assert(err < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
+  assert(((size_t)err) < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].name;
 }
 
 const char *
 http_errno_description(enum http_errno err) {
-  assert(err < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
+  assert(((size_t)err) < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].description;
 }
 

--- a/http_parser.c
+++ b/http_parser.c
@@ -123,7 +123,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-  
+
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)
@@ -1782,9 +1782,9 @@ reexecute:
 
         if (parser->flags & F_TRAILING) {
           /* End of a chunked request */
-          UPDATE_STATE(NEW_MESSAGE());
-          CALLBACK_NOTIFY(message_complete);
-          break;
+          UPDATE_STATE(s_message_done);
+          CALLBACK_NOTIFY_NOADVANCE(chunk_complete);
+          REEXECUTE();
         }
 
         UPDATE_STATE(s_headers_done);
@@ -1991,8 +1991,10 @@ reexecute:
         if (parser->content_length == 0) {
           parser->flags |= F_TRAILING;
           UPDATE_STATE(s_header_field_start);
+          CALLBACK_NOTIFY(chunk_header);
         } else {
           UPDATE_STATE(s_chunk_data);
+          CALLBACK_NOTIFY(chunk_header);
         }
         break;
       }
@@ -2033,6 +2035,7 @@ reexecute:
         STRICT_CHECK(ch != LF);
         parser->nread = 0;
         UPDATE_STATE(s_chunk_size_start);
+        CALLBACK_NOTIFY(chunk_complete);
         break;
 
       default:

--- a/http_parser.h
+++ b/http_parser.h
@@ -144,7 +144,7 @@ enum flags
 
 
 /* Map for errno-related constants
- * 
+ *
  * The provided argument should be a macro that takes 2 arguments.
  */
 #define HTTP_ERRNO_MAP(XX)                                           \
@@ -160,6 +160,8 @@ enum flags
   XX(CB_body, "the on_body callback failed")                         \
   XX(CB_message_complete, "the on_message_complete callback failed") \
   XX(CB_status, "the on_status callback failed")                     \
+  XX(CB_chunk_header, "the on_chunk_header callback failed")         \
+  XX(CB_chunk_complete, "the on_chunk_complete callback failed")     \
                                                                      \
   /* Parsing-related errors */                                       \
   XX(INVALID_EOF_STATE, "stream ended at an unexpected time")        \
@@ -240,6 +242,11 @@ struct http_parser_settings {
   http_cb      on_headers_complete;
   http_data_cb on_body;
   http_cb      on_message_complete;
+  /* When on_chunk_header is called, the current chunk length is stored
+   * in parser->content_length.
+   */
+  http_cb      on_chunk_header;
+  http_cb      on_chunk_complete;
 };
 
 

--- a/http_parser.h
+++ b/http_parser.h
@@ -144,7 +144,7 @@ enum flags
 
 
 /* Map for errno-related constants
- *
+ * 
  * The provided argument should be a macro that takes 2 arguments.
  */
 #define HTTP_ERRNO_MAP(XX)                                           \

--- a/test.c
+++ b/test.c
@@ -1876,7 +1876,7 @@ chunk_header_cb (http_parser *p)
   }
 
   int chunk_idx = messages[num_messages].num_chunks;
-  ++messages[num_messages].num_chunks;
+  messages[num_messages].num_chunks++;
   if (chunk_idx < MAX_CHUNKS) {
     messages[num_messages].chunk_lengths[chunk_idx] = p->content_length;
   }
@@ -1888,7 +1888,7 @@ int
 chunk_complete_cb (http_parser *p)
 {
   assert(p == parser);
-  ++messages[num_messages].num_chunks_complete;
+  messages[num_messages].num_chunks_complete++;
   return 0;
 }
 
@@ -3599,7 +3599,7 @@ main (void)
       ,.num_chunks= 31337
       ,.num_chunks_complete= 31338
       };
-    for (i = 0; i < MAX_CHUNKS; ++i) {
+    for (i = 0; i < MAX_CHUNKS; i++) {
       large_chunked.chunk_lengths[i] = 1024;
     }
     test_message_count_body(&large_chunked);

--- a/test.c
+++ b/test.c
@@ -2351,7 +2351,7 @@ upgrade_message_fix(char *body, const size_t nread, const size_t nmsgs, ...) {
   va_list ap;
   size_t i;
   size_t off = 0;
-
+ 
   va_start(ap, nmsgs);
 
   for (i = 0; i < nmsgs; i++) {


### PR DESCRIPTION
on_chunk_header & on_chunk_complete (Proxygen fork merge D508755 D521404, orig author simpkins@fb.com). Please see #231 for more details.