### PR TITLE
added regression test that verifies that old bugs regarding corrupted & ...

### DIFF
--- a/test.c
+++ b/test.c
@@ -2243,7 +2243,7 @@ upgrade_message_fix(char *body, const size_t nread, const size_t nmsgs, ...) {
   va_list ap;
   size_t i;
   size_t off = 0;
-
+ 
   va_start(ap, nmsgs);
 
   for (i = 0; i < nmsgs; i++) {

--- a/test.c
+++ b/test.c
@@ -2243,7 +2243,7 @@ upgrade_message_fix(char *body, const size_t nread, const size_t nmsgs, ...) {
   va_list ap;
   size_t i;
   size_t off = 0;
- 
+
   va_start(ap, nmsgs);
 
   for (i = 0; i < nmsgs; i++) {
@@ -3618,6 +3618,22 @@ main (void)
     "\t-----END CERTIFICATE-----\r\n"
     "\r\n";
   test_simple(dumbfuck2, HPE_OK);
+
+  const char *corrupted_connection =
+    "GET / HTTP/1.1\r\n"
+    "Host: www.example.com\r\n"
+    "Connection\r\033\065\325eep-Alive\r\n"
+    "Accept-Encoding: gzip\r\n"
+    "\r\n";
+  test_simple(corrupted_connection, HPE_INVALID_HEADER_TOKEN);
+
+  const char *corrupted_header_name =
+    "GET / HTTP/1.1\r\n"
+    "Host: www.example.com\r\n"
+    "X-Some-Header\r\033\065\325eep-Alive\r\n"
+    "Accept-Encoding: gzip\r\n"
+    "\r\n";
+  test_simple(corrupted_header_name, HPE_INVALID_HEADER_TOKEN);
 
 #if 0
   // NOTE(Wed Nov 18 11:57:27 CET 2009) this seems okay. we just read body


### PR DESCRIPTION
...incomplete headers are fixed (D512233 + D570451, orig authors brianp@fb.com + jtarnawski@fb.com). These were 2 regression tests that had been added to the proxygen fork of http_parser, I don't think they are redundant, but not 100% sure.