### PR TITLE
src: handle `Upgrade:` without `Conn: upgrade`

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1790,10 +1790,15 @@ reexecute:
         UPDATE_STATE(s_headers_done);
 
         /* Set this here so that on_headers_complete() callbacks can see it */
+#if HTTP_PARSER_STRICT
         parser->upgrade =
           ((parser->flags & (F_UPGRADE | F_CONNECTION_UPGRADE)) ==
            (F_UPGRADE | F_CONNECTION_UPGRADE) ||
            parser->method == HTTP_CONNECT);
+#else
+        parser->upgrade = (parser->flags & F_UPGRADE) ||
+            parser->method == HTTP_CONNECT;
+#endif
 
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we

--- a/test.c
+++ b/test.c
@@ -1036,6 +1036,30 @@ const struct message requests[] =
   ,.body= ""
   }
 
+#if !HTTP_PARSER_STRICT
+#define CONNECTION_UPGRADE_REGRESSION 38
+, {.name = "upgrade header with some random words"
+  ,.type= HTTP_REQUEST
+  ,.raw= "GET / HTTP/1.1\r\n"
+         "Upgrade: Yes, please.\r\n"
+         "\r\n"
+  ,.should_keep_alive= TRUE
+  ,.message_complete_on_eof= FALSE
+  ,.http_major= 1
+  ,.http_minor= 1
+  ,.method= HTTP_GET
+  ,.query_string= ""
+  ,.fragment= ""
+  ,.request_path= "/"
+  ,.request_url= "/"
+  ,.num_headers= 1
+  ,.upgrade=""
+  ,.headers= { { "Upgrade", "Yes, please." }
+             }
+  ,.body= ""
+  }
+#endif
+
 , {.name= NULL } /* sentinel */
 };
 


### PR DESCRIPTION
In strict mode this should not be treated as upgrade, in normal mode we
should be gentle and allow it.

Fix: https://github.com/joyent/http-parser/issues/217

cc @bnoordhuis @mscdex - this is a compromise solution, let's continue discussion here.