### PR TITLE
Support BIND, REBIND and UNBIND (WebDAV, RFC5842)

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -972,7 +972,7 @@ reexecute:
           case 'R': parser->method = HTTP_REPORT; /* or REBIND */ break;
           case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = HTTP_TRACE; break;
-          case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
+          case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE, UNBIND */ break;
           default:
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
@@ -1057,6 +1057,8 @@ reexecute:
           } else if (parser->method == HTTP_UNLOCK) {
             if (ch == 'S') {
               parser->method = HTTP_UNSUBSCRIBE;
+            } else if(ch == 'B') {
+              parser->method = HTTP_UNBIND;
             } else {
               SET_ERRNO(HPE_INVALID_METHOD);
               goto error;

--- a/http_parser.c
+++ b/http_parser.c
@@ -969,7 +969,7 @@ reexecute:
           case 'P': parser->method = HTTP_POST;
             /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */
             break;
-          case 'R': parser->method = HTTP_REPORT; break;
+          case 'R': parser->method = HTTP_REPORT; /* or REBIND */ break;
           case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = HTTP_TRACE; break;
           case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
@@ -1028,6 +1028,13 @@ reexecute:
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
+        } else if (parser->method == HTTP_REPORT) {
+            if (parser->index == 2 && ch == 'B') {
+              parser->method = HTTP_REBIND;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
         } else if (parser->index == 1 && parser->method == HTTP_POST) {
           if (ch == 'R') {
             parser->method = HTTP_PROPFIND; /* or HTTP_PROPPATCH */

--- a/http_parser.c
+++ b/http_parser.c
@@ -957,6 +957,7 @@ reexecute:
         parser->method = (enum http_method) 0;
         parser->index = 1;
         switch (ch) {
+          case 'B': parser->method = HTTP_BIND; break;
           case 'C': parser->method = HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
           case 'D': parser->method = HTTP_DELETE; break;
           case 'G': parser->method = HTTP_GET; break;

--- a/http_parser.h
+++ b/http_parser.h
@@ -95,7 +95,7 @@ typedef int (*http_cb) (http_parser*);
   XX(5,  CONNECT,     CONNECT)      \
   XX(6,  OPTIONS,     OPTIONS)      \
   XX(7,  TRACE,       TRACE)        \
-  /* webdav */                      \
+  /* WebDAV */                      \
   XX(8,  COPY,        COPY)         \
   XX(9,  LOCK,        LOCK)         \
   XX(10, MKCOL,       MKCOL)        \
@@ -104,21 +104,24 @@ typedef int (*http_cb) (http_parser*);
   XX(13, PROPPATCH,   PROPPATCH)    \
   XX(14, SEARCH,      SEARCH)       \
   XX(15, UNLOCK,      UNLOCK)       \
+  XX(16, BIND,        BIND)         \
+  XX(17, REBIND,      REBIND)       \
+  XX(18, UNBIND,      UNBIND)       \
   /* subversion */                  \
-  XX(16, REPORT,      REPORT)       \
-  XX(17, MKACTIVITY,  MKACTIVITY)   \
-  XX(18, CHECKOUT,    CHECKOUT)     \
-  XX(19, MERGE,       MERGE)        \
+  XX(19, REPORT,      REPORT)       \
+  XX(20, MKACTIVITY,  MKACTIVITY)   \
+  XX(21, CHECKOUT,    CHECKOUT)     \
+  XX(22, MERGE,       MERGE)        \
   /* upnp */                        \
-  XX(20, MSEARCH,     M-SEARCH)     \
-  XX(21, NOTIFY,      NOTIFY)       \
-  XX(22, SUBSCRIBE,   SUBSCRIBE)    \
-  XX(23, UNSUBSCRIBE, UNSUBSCRIBE)  \
+  XX(23, MSEARCH,     M-SEARCH)     \
+  XX(24, NOTIFY,      NOTIFY)       \
+  XX(25, SUBSCRIBE,   SUBSCRIBE)    \
+  XX(26, UNSUBSCRIBE, UNSUBSCRIBE)  \
   /* RFC-5789 */                    \
-  XX(24, PATCH,       PATCH)        \
-  XX(25, PURGE,       PURGE)        \
+  XX(27, PATCH,       PATCH)        \
+  XX(28, PURGE,       PURGE)        \
   /* CalDAV */                      \
-  XX(26, MKCALENDAR,  MKCALENDAR)   \
+  XX(29, MKCALENDAR,  MKCALENDAR)   \
 
 enum http_method
   {

--- a/test.c
+++ b/test.c
@@ -3692,6 +3692,7 @@ main (void)
     "PROPPATCH",
     "UNLOCK",
     "BIND",
+    "REBIND",
     "REPORT",
     "MKACTIVITY",
     "CHECKOUT",

--- a/test.c
+++ b/test.c
@@ -3691,6 +3691,7 @@ main (void)
     "PROPFIND",
     "PROPPATCH",
     "UNLOCK",
+    "BIND",
     "REPORT",
     "MKACTIVITY",
     "CHECKOUT",

--- a/test.c
+++ b/test.c
@@ -3693,6 +3693,7 @@ main (void)
     "UNLOCK",
     "BIND",
     "REBIND",
+    "UNBIND",
     "REPORT",
     "MKACTIVITY",
     "CHECKOUT",


### PR DESCRIPTION
This PR adds support for the following HTTP methods:
  * `BIND` http://tools.ietf.org/html/rfc5842#section-4,
  * `REBIND` http://tools.ietf.org/html/rfc5842#section-6,
  * `UNBIND` http://tools.ietf.org/html/rfc5842#section-5.

This is part of the WebDAV protocol.