### PR TITLE
Fix DESTDIR/PREFIX usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CFLAGS_LIB = $(CFLAGS_FAST) -fPIC
 LDFLAGS_LIB = $(LDFLAGS) -shared
 
 INSTALL ?= install
-PREFIX ?= $(DESTDIR)/usr/local
+PREFIX ?= /usr/local
 LIBDIR = $(PREFIX)/lib
 INCLUDEDIR = $(PREFIX)/include
 
@@ -112,18 +112,18 @@ tags: http_parser.c http_parser.h test.c
 
 install: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	$(INSTALL) -D $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
+	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	$(INSTALL) -D -s $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
+	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
 
 uninstall:
 	rm $(INCLUDEDIR)/http_parser.h
-	rm $(LIBDIR)/$(SONAME)
-	rm $(LIBDIR)/libhttp_parser.so
+	rm $(DESTDIR)/$(LIBDIR)/$(SONAME)
+	rm $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
 
 clean:
 	rm -f *.o *.a tags test test_fast test_g \

--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,12 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
-	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
+	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(SONAME) $(DESTDIR)/$(LIBDIR)/$(SONAME)
-	ln -s $(DESTDIR)/$(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
+	ln -s $(LIBDIR)/$(SONAME) $(DESTDIR)/$(LIBDIR)/libhttp_parser.so
 
 uninstall:
 	rm $(INCLUDEDIR)/http_parser.h


### PR DESCRIPTION
Installing http-parser with both, DESTDIR and PREFIX results in ignoring DESTDIR
completely. This is especially a bad thing in automized build environments. This
patch fixes this behavior to respect DESTDIR even if PREFIX is set.