### PR TITLE
Fix invalid memory access.

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2376,7 +2376,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   /* host must be present if there is a schema */
   /* parsing http:///toto will fail */
-  if ((u->field_set & ((1 << UF_SCHEMA) | (1 << UF_HOST))) != 0) {
+  if ((u->field_set & (1 << UF_SCHEMA)) != 0 && (u->field_set & (1 << UF_HOST)) != 0) {
     if (http_parse_host(buf, u, found_at) != 0) {
       return 1;
     }

--- a/http_parser.c
+++ b/http_parser.c
@@ -2376,12 +2376,8 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   /* host must be present if there is a schema */
   /* parsing http:///toto will fail */
-  if ((u->field_set & (1 << UF_SCHEMA)) && (u->field_set & (1 << UF_HOST)) == 0) {
-    return 1;
-  }
-
-  /* CONNECT requests can only contain "hostname:port" */
-  if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
+  if ((u->field_set & (1 << UF_SCHEMA)) &&
+      (u->field_set & (1 << UF_HOST)) == 0) {
     return 1;
   }
 
@@ -2389,6 +2385,11 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
     if (http_parse_host(buf, u, found_at) != 0) {
       return 1;
     }
+  }
+
+  /* CONNECT requests can only contain "hostname:port" */
+  if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
+	  return 1;
   }
 
   if (u->field_set & (1 << UF_PORT)) {

--- a/http_parser.c
+++ b/http_parser.c
@@ -2389,7 +2389,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   /* CONNECT requests can only contain "hostname:port" */
   if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
-	  return 1;
+    return 1;
   }
 
   if (u->field_set & (1 << UF_PORT)) {

--- a/http_parser.c
+++ b/http_parser.c
@@ -2376,15 +2376,19 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   /* host must be present if there is a schema */
   /* parsing http:///toto will fail */
-  if ((u->field_set & (1 << UF_SCHEMA)) != 0 && (u->field_set & (1 << UF_HOST)) != 0) {
-    if (http_parse_host(buf, u, found_at) != 0) {
-      return 1;
-    }
+  if ((u->field_set & (1 << UF_SCHEMA)) && (u->field_set & (1 << UF_HOST)) == 0) {
+    return 1;
   }
 
   /* CONNECT requests can only contain "hostname:port" */
   if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
     return 1;
+  }
+
+  if (u->field_set & (1 << UF_HOST)) {
+    if (http_parse_host(buf, u, found_at) != 0) {
+      return 1;
+    }
   }
 
   if (u->field_set & (1 << UF_PORT)) {

--- a/http_parser.c
+++ b/http_parser.c
@@ -2232,6 +2232,7 @@ http_parse_host_char(enum http_host_state s, const char ch) {
 
 static int
 http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
+  assert(u->field_set & (1 << UF_HOST));
   enum http_host_state s;
 
   const char *p;


### PR DESCRIPTION
http_parse_host() depends on u->field_data[UF_HOST], but this if()
allowed the method to be called if only u->field_data[UF_SCHEMA] was
set, resulting in use of unintialized pointers.