### PR TITLE
use ARRAY_SIZE instead of manual array size calculation

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -2152,15 +2152,13 @@ http_parser_settings_init(http_parser_settings *settings)
 
 const char *
 http_errno_name(enum http_errno err) {
-  assert(((size_t) err) <
-      (sizeof(http_strerror_tab) / sizeof(http_strerror_tab[0])));
+  assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
   return http_strerror_tab[err].name;
 }
 
 const char *
 http_errno_description(enum http_errno err) {
-  assert(((size_t) err) <
-      (sizeof(http_strerror_tab) / sizeof(http_strerror_tab[0])));
+  assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
   return http_strerror_tab[err].description;
 }
 


### PR DESCRIPTION
Reuse the already defined ARRAY_SIZE macro instead of manual array size calculation